### PR TITLE
Add pydantic-extra-types to output

### DIFF
--- a/src/run_python.ts
+++ b/src/run_python.ts
@@ -104,8 +104,8 @@ export async function runCode(
     throw e
   }
   await py.pyodide.runPythonAsync(`
-import pydantic, pydantic_core
-print(f'pydantic version: v{pydantic.__version__}, pydantic-core version: v{pydantic_core.__version__}')
+import pydantic, pydantic_core, pydantic_extra_types
+print(f'pydantic version: v{pydantic.__version__}, pydantic-core version: v{pydantic_core.__version__}', pydantic-extra-types version: v{pydantic_extra_types.__version__}')
 `)
   try {
     await py.pyodide.runPythonAsync(code)


### PR DESCRIPTION
Context: https://github.com/pydantic/pydantic/pull/9433

`pydantic-extra-types` is added to harmonize the output of the dependencies.