### PR TITLE
Also select "```python" blocks for run button

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ declare global {
 async function main() {
   await load_css()
   window.code_blocks = []
-  document.querySelectorAll('.language-py').forEach((block) => {
+  document.querySelectorAll('.language-py, .language-python').forEach((block) => {
     window.code_blocks.push(new CodeBlock(block))
   })
 }


### PR DESCRIPTION
We've moved to using "```python" instead of "```py" in `pydantic`.